### PR TITLE
Make the `vibe` parameter optional in the `find_gif` function

### DIFF
--- a/functions/find_gif.ts
+++ b/functions/find_gif.ts
@@ -15,7 +15,7 @@ export const FindGIFFunction = DefineFunction({
         description: "The energy for the GIF to match",
       },
     },
-    required: ["vibe"],
+    required: [],
   },
   output_parameters: {
     properties: {
@@ -57,6 +57,6 @@ const matchVibe = (vibe: string): GIF => {
 
 export default SlackFunction(FindGIFFunction, ({ inputs }) => {
   const { vibe } = inputs;
-  const gif = matchVibe(vibe);
+  const gif = matchVibe(vibe ?? "");
   return { outputs: gif };
 });

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.5.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.6.0/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.6.0/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.7.0/"
   }
 }

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.9.2/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.9.3/mod.ts"
   }
 }


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR fixes a bug that is raised during workflow executions when the optional `kudo_vibe` is `null` by making the `vibe` optional in the custom `find_gif` function. Closes #5.

Attempts were made to use [the nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) from within the workflow step input, but the error persisted, so the change was made at a function level.

Deno versions were also bumped to their latest.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
