### PR TITLE
Update dependencies

### DIFF
--- a/functions/find_gif.ts
+++ b/functions/find_gif.ts
@@ -1,5 +1,5 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
-import gifs from "../assets/gifs.json" assert { type: "json" };
+import gifs from "../assets/gifs.json" with { type: "json" };
 
 /**
  * Functions are reusable building blocks of automation that accept inputs,

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.5.0/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.1.2/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.6.0/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.2.0/"
   }
 }


### PR DESCRIPTION
Automated dependency bump with the latest Deno modules

[@srajiang ] added a fix for a linter error:
![Screenshot 2024-02-22 at 10 18 42 AM](https://github.com/slack-samples/deno-give-kudos/assets/55667998/fff0ee8d-04b0-4272-b984-3ea9f9fc56e6)
