### PR TITLE
Fix URL on message to enable giphy preview

### DIFF
--- a/workflows/give_kudos.ts
+++ b/workflows/give_kudos.ts
@@ -89,7 +89,7 @@ GiveKudosWorkflow.addStep(Schema.slack.functions.SendMessage, {
   message:
     `*Hey <@${kudo.outputs.fields.doer_of_good_deeds}>!* Someone wanted to share some kind words with you :otter:\n` +
     `> ${kudo.outputs.fields.kudo_message}\n` +
-    `${gif.outputs.URL}`,
+    `<${gif.outputs.URL}>`,
 });
 
 export { GiveKudosWorkflow };


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

Fixes #34 .
Adds angle brackets `<>` to the giphy URL so it is properly displayed as preview on the message sent.

I couldn't find the "Samples Checklist" to check the standards

### Requirements (place an x in each [ ] that applies)

- [ ] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
