### PR TITLE
fix: move gif list out of json and into a ts file

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,4 +1,4 @@
-name: Deno app build and testing
+name: Deno tests
 
 on:
   push:
@@ -10,15 +10,19 @@ jobs:
   deno:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        deno-version: [v1.x, v2.x]
 
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: ${{ matrix.deno-version }}
 
       - name: Verify formatting
         run: deno fmt --check

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -28,6 +28,6 @@
   },
   "lock": false,
   "tasks": {
-    "test": "deno fmt --check && deno lint && deno test --allow-read --allow-none"
+    "test": "deno fmt --check && deno lint && deno test --allow-read"
   }
 }

--- a/functions/find_gif.ts
+++ b/functions/find_gif.ts
@@ -1,5 +1,5 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
-import gifs from "../assets/gifs.json" with { type: "json" };
+import gifs from "./gifs.ts";
 
 /**
  * Functions are reusable building blocks of automation that accept inputs,
@@ -46,15 +46,10 @@ const getEnergy = (vibe: string): string => {
   return "otter"; // 🦦
 };
 
-interface GIF {
-  URL: string;
-  alt_text?: string;
-  tags: string[];
-}
 
-const matchVibe = (vibe: string): GIF => {
+const matchVibe = (vibe: string) => {
   const energy = getEnergy(vibe);
-  const matches = gifs.filter((g: GIF) => g.tags.includes(energy));
+  const matches = gifs.filter((g) => g.tags.includes(energy));
   const randomGIF = Math.floor(Math.random() * matches.length);
   return matches[randomGIF];
 };

--- a/functions/find_gif.ts
+++ b/functions/find_gif.ts
@@ -46,7 +46,6 @@ const getEnergy = (vibe: string): string => {
   return "otter"; // 🦦
 };
 
-
 const matchVibe = (vibe: string) => {
   const energy = getEnergy(vibe);
   const matches = gifs.filter((g) => g.tags.includes(energy));

--- a/functions/gifs.ts
+++ b/functions/gifs.ts
@@ -1,4 +1,10 @@
-[{
+interface GIF {
+  URL: string;
+  alt_text?: string;
+  tags: string[];
+}
+
+const gifList: GIF[] = [{
   "URL": "https://media2.giphy.com/media/3oEjHWXddcCOGZNmFO/giphy.gif",
   "alt_text": "A person wearing a banana hat says thanks a bunch",
   "tags": ["thankful"]
@@ -74,4 +80,6 @@
   "URL": "https://media0.giphy.com/media/tQAApm4PMOpiM/giphy.gif",
   "alt_text": "Floating otters holding hands. Aww",
   "tags": ["otter"]
-}]
+}];
+
+export default gifList;

--- a/functions/gifs.ts
+++ b/functions/gifs.ts
@@ -7,79 +7,83 @@ interface GIF {
 const gifList: GIF[] = [{
   "URL": "https://media2.giphy.com/media/3oEjHWXddcCOGZNmFO/giphy.gif",
   "alt_text": "A person wearing a banana hat says thanks a bunch",
-  "tags": ["thankful"]
+  "tags": ["thankful"],
 }, {
   "URL": "https://media2.giphy.com/media/ZfK4cXKJTTay1Ava29/giphy.gif",
   "alt_text": "Dwight from The Office says thank you",
-  "tags": ["thankful", "appreciation"]
+  "tags": ["thankful", "appreciation"],
 }, {
-  "URL": "https://media3.giphy.com/media/DhstvI3zZ598Nb1rFf/giphy-downsized.gif",
+  "URL":
+    "https://media3.giphy.com/media/DhstvI3zZ598Nb1rFf/giphy-downsized.gif",
   "alt_text": "Dancing at a disco party in The Office",
-  "tags": ["celebration"]
+  "tags": ["celebration"],
 }, {
   "URL": "https://media.giphy.com/media/3o6Zt2jsgmiAUl2ydi/giphy.gif",
   "alt_text": "An impressed sponge-like creature expresses amazement",
-  "tags": ["amazed"]
+  "tags": ["amazed"],
 }, {
   "URL": "https://media.giphy.com/media/WKdPOVCG5LPaM/giphy.gif",
   "alt_text": "A cheerful high-five from the newsroom",
-  "tags": ["celebration", "excited"]
+  "tags": ["celebration", "excited"],
 }, {
   "URL": "https://media1.giphy.com/media/Lcn0yF1RcLANG/giphy-downsized.gif",
   "alt_text": "Wow! A feeling of wild disbelief overwhelms the senses",
-  "tags": ["amazed"]
+  "tags": ["amazed"],
 }, {
   "URL": "https://media0.giphy.com/media/rgIdiNjWC933y/giphy.gif",
   "alt_text": "A kingly racoon nodding over many subjects",
-  "tags": ["excited", "amazed"]
+  "tags": ["excited", "amazed"],
 }, {
   "URL": "https://media0.giphy.com/media/kyLYXonQYYfwYDIeZl/giphy.gif",
   "alt_text": "Elmo dances in celebration",
-  "tags": ["celebration"]
+  "tags": ["celebration"],
 }, {
-  "URL": "https://media2.giphy.com/media/3ohs7NuHL3gjbe2uGI/giphy-downsized.gif",
+  "URL":
+    "https://media2.giphy.com/media/3ohs7NuHL3gjbe2uGI/giphy-downsized.gif",
   "alt_text": "You're noticed and appreciated <3",
-  "tags": ["appreciation"]
+  "tags": ["appreciation"],
 }, {
   "URL": "https://media2.giphy.com/media/o75ajIFH0QnQC3nCeD/giphy.gif",
   "alt_text": "Pam from The Office cheers",
-  "tags": ["celebration", "excited"]
+  "tags": ["celebration", "excited"],
 }, {
-  "URL": "https://media3.giphy.com/media/xTiN0CNHgoRf1Ha7CM/giphy-downsized.gif",
+  "URL":
+    "https://media3.giphy.com/media/xTiN0CNHgoRf1Ha7CM/giphy-downsized.gif",
   "alt_text": "Cotton candy kid having a sugar rush",
-  "tags": ["celebration", "excited"]
+  "tags": ["celebration", "excited"],
 }, {
   "URL": "https://media1.giphy.com/media/NEvPzZ8bd1V4Y/giphy-downsized.gif",
   "alt_text": "A profound nod of approval",
-  "tags": ["appreciation", "thankful"]
+  "tags": ["appreciation", "thankful"],
 }, {
   "URL": "https://media3.giphy.com/media/WFyvwq3xoTTMs/giphy.gif",
   "alt_text": "Ready to witness wonderfulness",
-  "tags": ["amazed"]
+  "tags": ["amazed"],
 }, {
   "URL": "https://media3.giphy.com/media/jz2VNqCrlFsPe/giphy.gif",
   "alt_text": "A gaping dog caught in perpetual amazement",
-  "tags": ["amazed"]
+  "tags": ["amazed"],
 }, {
   "URL": "https://media.giphy.com/media/l3JDHv2xpLbQ7Tjdm/giphy.gif",
   "alt_text": "Pleaceful plants perched by a window",
-  "tags": ["plants"]
+  "tags": ["plants"],
 }, {
   "URL": "https://media3.giphy.com/media/IbsQ8L4PTQ53SH7FnL/giphy.gif",
   "alt_text": "A potted plant receives much needed affection",
-  "tags": ["plants"]
+  "tags": ["plants"],
 }, {
   "URL": "https://media1.giphy.com/media/xUA7aOIFDR4ZgqLy8w/giphy.gif",
   "alt_text": "Fern having a messy hair day",
-  "tags": ["plants"]
+  "tags": ["plants"],
 }, {
-  "URL": "https://media1.giphy.com/media/MbAlP79yMRysHKUyHV/giphy-downsized.gif",
+  "URL":
+    "https://media1.giphy.com/media/MbAlP79yMRysHKUyHV/giphy-downsized.gif",
   "alt_text": "Sleepy otter rubs checks and yawns",
-  "tags": ["otter"]
+  "tags": ["otter"],
 }, {
   "URL": "https://media0.giphy.com/media/tQAApm4PMOpiM/giphy.gif",
   "alt_text": "Floating otters holding hands. Aww",
-  "tags": ["otter"]
+  "tags": ["otter"],
 }];
 
 export default gifList;


### PR DESCRIPTION
This relates to deno 2 and esbuild compatibility for bundling. Import specifiers (e.g. `import gifs from "../assets/gifs.json" with { type: "json" };` - the `with` part) do not play nicely in the combination of deno 2 + esbuild, leading to issues with this sample when attempting to deploy it.

Fixes #45 

Also: expand GitHub Actions CI to run tests against both deno 1 and deno 2